### PR TITLE
Sort libraries by name

### DIFF
--- a/web/src/services/LibrariesService.ts
+++ b/web/src/services/LibrariesService.ts
@@ -51,7 +51,9 @@ export class LibrariesService {
   }
 
   public listLibraries(): Promise<Library[]> {
-    return this.api.getAllPages('/libraries/');
+    return this.api
+      .getAllPages<Library>('/libraries/')
+      .then((l) => [...l].sort((a, b) => a.name.localeCompare(b.name)));
   }
 
   public createLibrary(library: CreateLibrary): Promise<Library> {


### PR DESCRIPTION
Manual ordering might be nice at some point, but this is a nice and easy improvement so it's at least consistent.