### PR TITLE
Persistent details panel

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -301,9 +301,7 @@ var doc = `{
                         }
                     }
                 }
-            }
-        },
-        "/api/libraries/{libraryId}/entries/{path}": {
+            },
             "delete": {
                 "security": [
                     {
@@ -322,7 +320,7 @@ var doc = `{
                         "type": "string",
                         "description": "The url encoded path",
                         "name": "path",
-                        "in": "path",
+                        "in": "query",
                         "required": true
                     },
                     {
@@ -340,7 +338,7 @@ var doc = `{
                 }
             }
         },
-        "/api/libraries/{libraryId}/entries/{path}/download": {
+        "/api/libraries/{libraryId}/entries/download": {
             "get": {
                 "security": [
                     {
@@ -354,9 +352,9 @@ var doc = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The url encoded path",
+                        "description": "The file path",
                         "name": "path",
-                        "in": "path",
+                        "in": "query",
                         "required": true
                     },
                     {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -350,7 +350,7 @@ var doc = `{
                 "tags": [
                     "Files"
                 ],
-                "summary": "Search the collection of files and folders",
+                "summary": "Download a file",
                 "parameters": [
                     {
                         "type": "string",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -225,6 +225,12 @@ var doc = `{
                         "in": "query"
                     },
                     {
+                        "type": "string",
+                        "description": "The entry path. If this value is set, all other parameters are ignored and a maximum of 1 value is returned.",
+                        "name": "path",
+                        "in": "query"
+                    },
+                    {
                         "type": "integer",
                         "description": "The library id",
                         "name": "libraryId",
@@ -298,44 +304,6 @@ var doc = `{
             }
         },
         "/api/libraries/{libraryId}/entries/{path}": {
-            "get": {
-                "security": [
-                    {
-                        "OAuth2": []
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Files"
-                ],
-                "summary": "Search the collection of files and folders",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "The url encoded path",
-                        "name": "path",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "The library id",
-                        "name": "libraryId",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/service.FileInfo"
-                        }
-                    }
-                }
-            },
             "delete": {
                 "security": [
                     {
@@ -814,6 +782,9 @@ var doc = `{
                     "items": {
                         "$ref": "#/definitions/controller.BrowseResponseFolder"
                     }
+                },
+                "parent": {
+                    "type": "string"
                 },
                 "path": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -283,9 +283,7 @@
                         }
                     }
                 }
-            }
-        },
-        "/api/libraries/{libraryId}/entries/{path}": {
+            },
             "delete": {
                 "security": [
                     {
@@ -304,7 +302,7 @@
                         "type": "string",
                         "description": "The url encoded path",
                         "name": "path",
-                        "in": "path",
+                        "in": "query",
                         "required": true
                     },
                     {
@@ -322,7 +320,7 @@
                 }
             }
         },
-        "/api/libraries/{libraryId}/entries/{path}/download": {
+        "/api/libraries/{libraryId}/entries/download": {
             "get": {
                 "security": [
                     {
@@ -336,9 +334,9 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The url encoded path",
+                        "description": "The file path",
                         "name": "path",
-                        "in": "path",
+                        "in": "query",
                         "required": true
                     },
                     {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -332,7 +332,7 @@
                 "tags": [
                     "Files"
                 ],
-                "summary": "Search the collection of files and folders",
+                "summary": "Download a file",
                 "parameters": [
                     {
                         "type": "string",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -207,6 +207,12 @@
                         "in": "query"
                     },
                     {
+                        "type": "string",
+                        "description": "The entry path. If this value is set, all other parameters are ignored and a maximum of 1 value is returned.",
+                        "name": "path",
+                        "in": "query"
+                    },
+                    {
                         "type": "integer",
                         "description": "The library id",
                         "name": "libraryId",
@@ -280,44 +286,6 @@
             }
         },
         "/api/libraries/{libraryId}/entries/{path}": {
-            "get": {
-                "security": [
-                    {
-                        "OAuth2": []
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Files"
-                ],
-                "summary": "Search the collection of files and folders",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "The url encoded path",
-                        "name": "path",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "The library id",
-                        "name": "libraryId",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/service.FileInfo"
-                        }
-                    }
-                }
-            },
             "delete": {
                 "security": [
                     {
@@ -796,6 +764,9 @@
                     "items": {
                         "$ref": "#/definitions/controller.BrowseResponseFolder"
                     }
+                },
+                "parent": {
+                    "type": "string"
                 },
                 "path": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -449,7 +449,7 @@ paths:
           description: ""
       security:
       - OAuth2: []
-      summary: Search the collection of files and folders
+      summary: Download a file
       tags:
       - Files
   /api/libraries/{libraryId}/shares:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -344,6 +344,28 @@ paths:
       tags:
       - Files
   /api/libraries/{libraryId}/entries:
+    delete:
+      parameters:
+      - description: The url encoded path
+        in: query
+        name: path
+        required: true
+        type: string
+      - description: The library id
+        in: path
+        name: libraryId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: ""
+      security:
+      - OAuth2: []
+      summary: Delete a file or folder
+      tags:
+      - Files
     get:
       parameters:
       - description: The parent folder
@@ -408,34 +430,11 @@ paths:
       summary: Create a new file or folder
       tags:
       - Files
-  /api/libraries/{libraryId}/entries/{path}:
-    delete:
-      parameters:
-      - description: The url encoded path
-        in: path
-        name: path
-        required: true
-        type: string
-      - description: The library id
-        in: path
-        name: libraryId
-        required: true
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "204":
-          description: ""
-      security:
-      - OAuth2: []
-      summary: Delete a file or folder
-      tags:
-      - Files
-  /api/libraries/{libraryId}/entries/{path}/download:
+  /api/libraries/{libraryId}/entries/download:
     get:
       parameters:
-      - description: The url encoded path
-        in: path
+      - description: The file path
+        in: query
         name: path
         required: true
         type: string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -21,6 +21,8 @@ definitions:
         items:
           $ref: '#/definitions/controller.BrowseResponseFolder'
         type: array
+      parent:
+        type: string
       path:
         type: string
     type: object
@@ -348,6 +350,11 @@ paths:
         in: query
         name: parent
         type: string
+      - description: The entry path. If this value is set, all other parameters are
+          ignored and a maximum of 1 value is returned.
+        in: query
+        name: path
+        type: string
       - description: The library id
         in: path
         name: libraryId
@@ -422,30 +429,6 @@ paths:
       security:
       - OAuth2: []
       summary: Delete a file or folder
-      tags:
-      - Files
-    get:
-      parameters:
-      - description: The url encoded path
-        in: path
-        name: path
-        required: true
-        type: string
-      - description: The library id
-        in: path
-        name: libraryId
-        required: true
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/service.FileInfo'
-      security:
-      - OAuth2: []
-      summary: Search the collection of files and folders
       tags:
       - Files
   /api/libraries/{libraryId}/entries/{path}/download:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module clearcloud
 go 1.16
 
 require (
-	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/gin-gonic/gin v1.7.2
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
@@ -12,7 +11,7 @@ require (
 	github.com/go-playground/validator/v10 v10.6.1
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.2.0
-	github.com/jackc/pgx/v4 v4.11.0 // indirect
+	github.com/jackc/pgx/v4 v4.11.0
 	github.com/json-iterator/go v1.1.11 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
@@ -22,9 +21,9 @@ require (
 	github.com/swaggo/swag v1.7.0
 	github.com/ugorji/go v1.2.6 // indirect
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
-	golang.org/x/net v0.0.0-20210610132358-84b48f89b13b // indirect
-	golang.org/x/sys v0.0.0-20210611083646-a4fc73990273 // indirect
-	golang.org/x/tools v0.1.3 // indirect
+	golang.org/x/net v0.0.0-20210716203947-853a461950ff // indirect
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
+	golang.org/x/tools v0.1.5 // indirect
 	gorm.io/driver/postgres v1.1.0
 	gorm.io/gorm v1.21.10
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
-github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
@@ -487,8 +485,8 @@ golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210421230115-4e50805a0758/go.mod h1:72T/g9IO56b78aLF+1Kcs5dz7/ng1VjMUvfKvpfy+jM=
-golang.org/x/net v0.0.0-20210610132358-84b48f89b13b h1:k+E048sYJHyVnsr1GDrRZWQ32D2C7lWs9JRc0bel53A=
-golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210716203947-853a461950ff h1:j2EK/QoxYNBsXI4R7fQkkRUk8y6wnOBI+6hgPdP/6Ds=
+golang.org/x/net v0.0.0-20210716203947-853a461950ff/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -527,8 +525,8 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210420072515-93ed5bcd2bfe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210611083646-a4fc73990273 h1:faDu4veV+8pcThn4fewv6TVlNCezafGoC1gM/mxQLbQ=
-golang.org/x/sys v0.0.0-20210611083646-a4fc73990273/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -558,8 +556,8 @@ golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20201120155355-20be4ac4bd6e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.1.3 h1:L69ShwSZEyCsLKoAxDKeMvLDZkumEe8gXUZAjab0tX8=
-golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
+golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/controller/Entries.go
+++ b/internal/controller/Entries.go
@@ -99,7 +99,7 @@ func ListEntries(db *gorm.DB, libs *service.Library, fs *service.FileSystem) gin
 // DownloadEntry
 // @Tags Files
 // @Router /api/libraries/{libraryId}/entries/{path}/download [get]
-// @Summary Search the collection of files and folders
+// @Summary Download a file
 // @Security OAuth2
 // @Success 200
 // @Param path path string true "The url encoded path"

--- a/internal/controller/Entries_test.go
+++ b/internal/controller/Entries_test.go
@@ -33,9 +33,7 @@ func TestListEntries(t *testing.T) {
 		recorder := httptest.NewRecorder()
 		testApp.Router.ServeHTTP(recorder, req)
 
-		if recorder.Code != 200 {
-			t.Errorf("Expected 200 but got: %d", recorder.Code)
-		}
+		assertStatus(t, recorder, 200)
 		var body []service.FileInfo
 		if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
 			t.Errorf("Invalid response body: %s", err)
@@ -53,9 +51,7 @@ func TestListEntries(t *testing.T) {
 		recorder := httptest.NewRecorder()
 		testApp.Router.ServeHTTP(recorder, req)
 
-		if recorder.Code != 200 {
-			t.Errorf("Expected 200 but got: %d", recorder.Code)
-		}
+		assertStatus(t, recorder, 200)
 		var body []interface{}
 		if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
 			t.Errorf("Invalid response body: %s", err)
@@ -108,10 +104,7 @@ func TestDownloadEntry(t *testing.T) {
 			recorder,
 			req,
 		)
-		status := recorder.Code
-		if status != 404 {
-			t.Errorf("Expected 404 but got: %d", status)
-		}
+		assertStatus(t, recorder, 404)
 	})
 
 	t.Run("it returns 404 if no access to library", func(t *testing.T) {
@@ -121,10 +114,7 @@ func TestDownloadEntry(t *testing.T) {
 			recorder,
 			req,
 		)
-		status := recorder.Code
-		if status != 404 {
-			t.Errorf("Expected 404 but got: %d", status)
-		}
+		assertStatus(t, recorder, 404)
 	})
 
 	t.Run("it returns 400 if no path provided", func(t *testing.T) {
@@ -134,10 +124,7 @@ func TestDownloadEntry(t *testing.T) {
 			recorder,
 			req,
 		)
-		status := recorder.Code
-		if status != 400 {
-			t.Errorf("Expected 400 but got: %d", status)
-		}
+		assertStatus(t, recorder, 400)
 	})
 
 	t.Run("it returns 400 if path not encoded", func(t *testing.T) {
@@ -148,10 +135,7 @@ func TestDownloadEntry(t *testing.T) {
 			recorder,
 			req,
 		)
-		status := recorder.Code
-		if status != 400 {
-			t.Errorf("Expected 400 but got: %d", status)
-		}
+		assertStatus(t, recorder, 400)
 	})
 
 	t.Run("it requires authentication", func(t *testing.T) {
@@ -162,9 +146,6 @@ func TestDownloadEntry(t *testing.T) {
 			recorder,
 			req,
 		)
-		status := recorder.Code
-		if status != 401 {
-			t.Errorf("Expected 401 but got: %d", status)
-		}
+		assertStatus(t, recorder, 401)
 	})
 }

--- a/internal/controller/Entries_test.go
+++ b/internal/controller/Entries_test.go
@@ -71,7 +71,7 @@ func TestDownloadEntry(t *testing.T) {
 
 	// Go!
 	t.Run("it downloads a file", func(t *testing.T) {
-		req := adminRequest("GET", fmt.Sprintf("/api/libraries/%d/entries/gimme.txt/download", lib.ID), nil)
+		req := adminRequest("GET", fmt.Sprintf("/api/libraries/%d/entries/download?path=gimme.txt", lib.ID), nil)
 		recorder := httptest.NewRecorder()
 		testApp.Router.ServeHTTP(
 			recorder,
@@ -93,7 +93,7 @@ func TestDownloadEntry(t *testing.T) {
 	})
 
 	t.Run("it returns 404 if file not found", func(t *testing.T) {
-		req := adminRequest("GET", fmt.Sprintf("/api/libraries/%d/entries/nope.txt/download", lib.ID), nil)
+		req := adminRequest("GET", fmt.Sprintf("/api/libraries/%d/entries/download?path=nope.txt", lib.ID), nil)
 		recorder := httptest.NewRecorder()
 		testApp.Router.ServeHTTP(
 			recorder,
@@ -103,7 +103,7 @@ func TestDownloadEntry(t *testing.T) {
 	})
 
 	t.Run("it returns 404 if no access to library", func(t *testing.T) {
-		req := noAccessUserRequest("GET", fmt.Sprintf("/api/libraries/%d/entries/gimme.txt/download", lib.ID), nil)
+		req := noAccessUserRequest("GET", fmt.Sprintf("/api/libraries/%d/entries/download?path=gimme.txt", lib.ID), nil)
 		recorder := httptest.NewRecorder()
 		testApp.Router.ServeHTTP(
 			recorder,
@@ -113,18 +113,7 @@ func TestDownloadEntry(t *testing.T) {
 	})
 
 	t.Run("it returns 400 if no path provided", func(t *testing.T) {
-		req := adminRequest("GET", fmt.Sprintf("/api/libraries/%d/entries//download", lib.ID), nil)
-		recorder := httptest.NewRecorder()
-		testApp.Router.ServeHTTP(
-			recorder,
-			req,
-		)
-		assertStatus(t, recorder, 400)
-	})
-
-	t.Run("it returns 400 if path not encoded", func(t *testing.T) {
-		req := adminRequest("GET", "/simple", nil)
-		req.URL.Path = fmt.Sprintf("/api/libraries/%d/entries/what is this sh%%it!/download", lib.ID)
+		req := adminRequest("GET", fmt.Sprintf("/api/libraries/%d/entries/download", lib.ID), nil)
 		recorder := httptest.NewRecorder()
 		testApp.Router.ServeHTTP(
 			recorder,
@@ -134,8 +123,7 @@ func TestDownloadEntry(t *testing.T) {
 	})
 
 	t.Run("it requires authentication", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/simple", nil)
-		req.URL.Path = fmt.Sprintf("/api/libraries/%d/entries/what is this sh%%it!/download", lib.ID)
+		req, _ := http.NewRequest("GET", fmt.Sprintf("/api/libraries/%d/entries/download?path=not_allowed", lib.ID), nil)
 		recorder := httptest.NewRecorder()
 		testApp.Router.ServeHTTP(
 			recorder,

--- a/internal/controller/Entries_test.go
+++ b/internal/controller/Entries_test.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"clearcloud/internal/model"
 	"clearcloud/internal/service"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -35,9 +34,7 @@ func TestListEntries(t *testing.T) {
 
 		assertStatus(t, recorder, 200)
 		var body []service.FileInfo
-		if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
-			t.Errorf("Invalid response body: %s", err)
-		}
+		assertJsonUnmarshal(t, recorder, &body)
 		if len(body) != 2 {
 			t.Errorf("Expected 2 files, but got %d", len(body))
 		}
@@ -53,9 +50,7 @@ func TestListEntries(t *testing.T) {
 
 		assertStatus(t, recorder, 200)
 		var body []interface{}
-		if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
-			t.Errorf("Invalid response body: %s", err)
-		}
+		assertJsonUnmarshal(t, recorder, &body)
 		if len(body) > 0 {
 			t.Errorf("Expected an empty list but got: %s", recorder.Body.String())
 		}

--- a/internal/controller/Entries_test.go
+++ b/internal/controller/Entries_test.go
@@ -72,6 +72,19 @@ func TestListEntries(t *testing.T) {
 		}
 	})
 
+	t.Run("it returns an empty list when querying the root path", func(t *testing.T) {
+		req := adminRequest("GET", fmt.Sprintf("/api/libraries/%d/entries?path=", lib.ID), nil)
+		recorder := httptest.NewRecorder()
+		testApp.Router.ServeHTTP(recorder, req)
+
+		assertStatus(t, recorder, 200)
+		var body []interface{}
+		assertJsonUnmarshal(t, recorder, &body)
+		if len(body) > 0 {
+			t.Errorf("Expected an empty list but got: %s", recorder.Body.String())
+		}
+	})
+
 	t.Run("it requires authentication", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", fmt.Sprintf("/api/libraries/%d/entries?path=root.txt", lib.ID), nil)
 		recorder := httptest.NewRecorder()

--- a/internal/controller/Entries_test.go
+++ b/internal/controller/Entries_test.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"clearcloud/internal/model"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -11,52 +10,8 @@ import (
 	"testing"
 )
 
-func TestGetLibrary(t *testing.T) {
-
-	lib := model.Library{
-		Type:       model.TypeGeneric,
-		Name:       "Test Library",
-		RootFolder: "/",
-	}
-	testApp.DB.Create(&lib)
-	readAccess := model.CanAccessLibrary{
-		User:     regularUser,
-		Library:  lib,
-		CanWrite: true,
-	}
-	testApp.DB.Create(&readAccess)
-
-	t.Run("requires admin access", func(t *testing.T) {
-		req := regularUserRequest("GET", fmt.Sprintf("/api/libraries/%d", lib.ID), nil)
-		recorder := httptest.NewRecorder()
-		testApp.Router.ServeHTTP(
-			recorder,
-			req,
-		)
-
-		status := recorder.Code
-		if status != 403 {
-			t.Errorf("Expected forbidden (403) but got: %d", status)
-		}
-	})
-
-	t.Run("returns shares", func(t *testing.T) {
-		req := adminRequest("GET", fmt.Sprintf("/api/libraries/%d", lib.ID), nil)
-		recorder := httptest.NewRecorder()
-		testApp.Router.ServeHTTP(
-			recorder,
-			req,
-		)
-		body := map[string]interface{}{}
-		_ = json.Unmarshal(recorder.Body.Bytes(), &body)
-		if body["sharedWith"].([]interface{})[0].(map[string]interface{})["username"] == "simple-access" {
-			t.Errorf("Expected a share but instead got: %s", recorder.Body.String())
-		}
-	})
-}
-
 func TestDownloadEntry(t *testing.T) {
-	// Prep filesystem\
+	// Prep filesystem
 	tempDir := t.TempDir()
 	_ = os.WriteFile(filepath.Join(tempDir, "gimme.txt"), []byte("Hello World!\n"), 0777)
 

--- a/internal/controller/Entries_test.go
+++ b/internal/controller/Entries_test.go
@@ -43,6 +43,22 @@ func TestListEntries(t *testing.T) {
 		}
 	})
 
+	t.Run("it returns a single entry when querying a path", func(t *testing.T) {
+		req := adminRequest("GET", fmt.Sprintf("/api/libraries/%d/entries?path=root.txt", lib.ID), nil)
+		recorder := httptest.NewRecorder()
+		testApp.Router.ServeHTTP(recorder, req)
+
+		assertStatus(t, recorder, 200)
+		var body []service.FileInfo
+		assertJsonUnmarshal(t, recorder, &body)
+		if len(body) != 1 {
+			t.Errorf("Expected 1 file, but got %d", len(body))
+		}
+		if body[0].Name != "root.txt" {
+			t.Errorf("Expected root.txt, but got: %s", body[0].Name)
+		}
+	})
+
 	t.Run("it returns an empty list when querying a path that does not exist", func(t *testing.T) {
 		req := adminRequest("GET", fmt.Sprintf("/api/libraries/%d/entries?path=%s", lib.ID, url.QueryEscape("/no/file/here")), nil)
 		recorder := httptest.NewRecorder()

--- a/internal/controller/Libraries_test.go
+++ b/internal/controller/Libraries_test.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"clearcloud/internal/model"
-	"encoding/json"
 	"fmt"
 	"net/http/httptest"
 	"testing"
@@ -43,7 +42,7 @@ func TestGetLibrary(t *testing.T) {
 
 		assertStatus(t, recorder, 200)
 		body := map[string]interface{}{}
-		_ = json.Unmarshal(recorder.Body.Bytes(), &body)
+		assertJsonUnmarshal(t, recorder, &body)
 		if body["sharedWith"].([]interface{})[0].(map[string]interface{})["username"] == "simple-access" {
 			t.Errorf("Expected a share but instead got: %s", recorder.Body.String())
 		}

--- a/internal/controller/Libraries_test.go
+++ b/internal/controller/Libraries_test.go
@@ -30,10 +30,7 @@ func TestGetLibrary(t *testing.T) {
 			req,
 		)
 
-		status := recorder.Code
-		if status != 403 {
-			t.Errorf("Expected forbidden (403) but got: %d", status)
-		}
+		assertStatus(t, recorder, 403)
 	})
 
 	t.Run("returns shares", func(t *testing.T) {
@@ -43,6 +40,8 @@ func TestGetLibrary(t *testing.T) {
 			recorder,
 			req,
 		)
+
+		assertStatus(t, recorder, 200)
 		body := map[string]interface{}{}
 		_ = json.Unmarshal(recorder.Body.Bytes(), &body)
 		if body["sharedWith"].([]interface{})[0].(map[string]interface{})["username"] == "simple-access" {

--- a/internal/controller/Libraries_test.go
+++ b/internal/controller/Libraries_test.go
@@ -1,0 +1,52 @@
+package controller
+
+import (
+	"clearcloud/internal/model"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetLibrary(t *testing.T) {
+	lib := model.Library{
+		Type:       model.TypeGeneric,
+		Name:       "Test Library",
+		RootFolder: "/",
+	}
+	testApp.DB.Create(&lib)
+	readAccess := model.CanAccessLibrary{
+		User:     regularUser,
+		Library:  lib,
+		CanWrite: true,
+	}
+	testApp.DB.Create(&readAccess)
+
+	t.Run("requires admin access", func(t *testing.T) {
+		req := regularUserRequest("GET", fmt.Sprintf("/api/libraries/%d", lib.ID), nil)
+		recorder := httptest.NewRecorder()
+		testApp.Router.ServeHTTP(
+			recorder,
+			req,
+		)
+
+		status := recorder.Code
+		if status != 403 {
+			t.Errorf("Expected forbidden (403) but got: %d", status)
+		}
+	})
+
+	t.Run("returns shares", func(t *testing.T) {
+		req := adminRequest("GET", fmt.Sprintf("/api/libraries/%d", lib.ID), nil)
+		recorder := httptest.NewRecorder()
+		testApp.Router.ServeHTTP(
+			recorder,
+			req,
+		)
+		body := map[string]interface{}{}
+		_ = json.Unmarshal(recorder.Body.Bytes(), &body)
+		if body["sharedWith"].([]interface{})[0].(map[string]interface{})["username"] == "simple-access" {
+			t.Errorf("Expected a share but instead got: %s", recorder.Body.String())
+		}
+	})
+}

--- a/internal/controller/OAuth_test.go
+++ b/internal/controller/OAuth_test.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"encoding/json"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -26,7 +25,7 @@ func TestToken(t *testing.T) {
 			t.Errorf("Expected text/plain but got: %s", contentType)
 		}
 		body := map[string]interface{}{}
-		_ = json.Unmarshal(recorder.Body.Bytes(), &body)
+		assertJsonUnmarshal(t, recorder, &body)
 		if body["access_token"] == nil {
 			t.Errorf("Expected to find an access_token instead got: %s", recorder.Body.String())
 		}
@@ -49,7 +48,7 @@ func TestToken(t *testing.T) {
 			t.Errorf("Expected text/plain but got: %s", contentType)
 		}
 		body := map[string]interface{}{}
-		_ = json.Unmarshal(recorder.Body.Bytes(), &body)
+		assertJsonUnmarshal(t, recorder, &body)
 		if body["access_token"] == nil {
 			t.Errorf("Expected to find an access_token instead got: %s", recorder.Body.String())
 		}

--- a/internal/controller/OAuth_test.go
+++ b/internal/controller/OAuth_test.go
@@ -30,10 +30,7 @@ func TestToken(t *testing.T) {
 		if body["access_token"] == nil {
 			t.Errorf("Expected to find an access_token instead got: %s", recorder.Body.String())
 		}
-		status := recorder.Code
-		if status != 200 {
-			t.Errorf("Expected status 200 but got %d", status)
-		}
+		assertStatus(t, recorder, 200)
 	})
 
 	t.Run("the username is case insensitive", func(t *testing.T) {
@@ -56,10 +53,7 @@ func TestToken(t *testing.T) {
 		if body["access_token"] == nil {
 			t.Errorf("Expected to find an access_token instead got: %s", recorder.Body.String())
 		}
-		status := recorder.Code
-		if status != 200 {
-			t.Errorf("Expected status 200 but got %d", status)
-		}
+		assertStatus(t, recorder, 200)
 	})
 
 	t.Run("invalid credentials are rejected", func(t *testing.T) {
@@ -73,10 +67,7 @@ func TestToken(t *testing.T) {
 			req,
 		)
 
-		status := recorder.Code
-		if status != 400 {
-			t.Errorf("Expected status 400 but got %d", status)
-		}
+		assertStatus(t, recorder, 400)
 	})
 
 	t.Run("the password is case sensitive", func(t *testing.T) {
@@ -89,10 +80,7 @@ func TestToken(t *testing.T) {
 			recorder,
 			req,
 		)
-		status := recorder.Code
-		if status != 400 {
-			t.Errorf("Expected status 400 but got %d", status)
-		}
+		assertStatus(t, recorder, 400)
 	})
 
 	t.Run("client_id is required", func(t *testing.T) {
@@ -105,10 +93,7 @@ func TestToken(t *testing.T) {
 			recorder,
 			req,
 		)
-		status := recorder.Code
-		if status != 400 {
-			t.Errorf("Expected status 400 but got %d", status)
-		}
+		assertStatus(t, recorder, 400)
 	})
 
 	t.Run("grant_type is required", func(t *testing.T) {
@@ -121,10 +106,7 @@ func TestToken(t *testing.T) {
 			recorder,
 			req,
 		)
-		status := recorder.Code
-		if status != 400 {
-			t.Errorf("Expected status 400 but got %d", status)
-		}
+		assertStatus(t, recorder, 400)
 	})
 
 	t.Run("username is required", func(t *testing.T) {
@@ -137,10 +119,7 @@ func TestToken(t *testing.T) {
 			recorder,
 			req,
 		)
-		status := recorder.Code
-		if status != 400 {
-			t.Errorf("Expected status 400 but got %d", status)
-		}
+		assertStatus(t, recorder, 400)
 	})
 
 	t.Run("password is required", func(t *testing.T) {
@@ -153,10 +132,7 @@ func TestToken(t *testing.T) {
 			recorder,
 			req,
 		)
-		status := recorder.Code
-		if status != 400 {
-			t.Errorf("Expected status 400 but got %d", status)
-		}
+		assertStatus(t, recorder, 400)
 	})
 
 	t.Run("client_id must be web", func(t *testing.T) {
@@ -169,10 +145,7 @@ func TestToken(t *testing.T) {
 			recorder,
 			req,
 		)
-		status := recorder.Code
-		if status != 401 {
-			t.Errorf("Expected status 401 but got %d", status)
-		}
+		assertStatus(t, recorder, 401)
 	})
 
 	t.Run("grant_type must be password", func(t *testing.T) {
@@ -185,9 +158,6 @@ func TestToken(t *testing.T) {
 			recorder,
 			req,
 		)
-		status := recorder.Code
-		if status != 400 {
-			t.Errorf("Expected status 400 but got %d", status)
-		}
+		assertStatus(t, recorder, 400)
 	})
 }

--- a/internal/controller/app.go
+++ b/internal/controller/app.go
@@ -112,8 +112,8 @@ func NewApp(dbDiag gorm.Dialector) (app App, err error) {
 			{
 				entries.GET("", ListEntries(app.DB, app.Libraries, app.FileSystem))
 				entries.POST("", CreateEntry(app.DB, app.Libraries, app.FileSystem))
-				entries.GET("/:path/download", DownloadEntry(app.DB, app.Libraries, app.FileSystem))
-				entries.DELETE("/:path", DeleteEntry(app.DB, app.Libraries, app.FileSystem))
+				entries.GET("/download", DownloadEntry(app.DB, app.Libraries, app.FileSystem))
+				entries.DELETE("", DeleteEntry(app.DB, app.Libraries, app.FileSystem))
 			}
 		}
 		system := api.Group("/system")

--- a/internal/controller/app.go
+++ b/internal/controller/app.go
@@ -112,7 +112,6 @@ func NewApp(dbDiag gorm.Dialector) (app App, err error) {
 			{
 				entries.GET("", ListEntries(app.DB, app.Libraries, app.FileSystem))
 				entries.POST("", CreateEntry(app.DB, app.Libraries, app.FileSystem))
-				entries.GET("/:path", GetEntry(app.DB, app.Libraries, app.FileSystem))
 				entries.GET("/:path/download", DownloadEntry(app.DB, app.Libraries, app.FileSystem))
 				entries.DELETE("/:path", DeleteEntry(app.DB, app.Libraries, app.FileSystem))
 			}

--- a/internal/controller/assert_test.go
+++ b/internal/controller/assert_test.go
@@ -1,0 +1,12 @@
+package controller
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func assertStatus(t *testing.T, recorder *httptest.ResponseRecorder, status int) {
+	if recorder.Code != status {
+		t.Errorf("Expected status %d but got: %d", status, recorder.Code)
+	}
+}

--- a/internal/controller/assert_test.go
+++ b/internal/controller/assert_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"encoding/json"
 	"net/http/httptest"
 	"testing"
 )
@@ -8,5 +9,11 @@ import (
 func assertStatus(t *testing.T, recorder *httptest.ResponseRecorder, status int) {
 	if recorder.Code != status {
 		t.Errorf("Expected status %d but got: %d", status, recorder.Code)
+	}
+}
+
+func assertJsonUnmarshal(t *testing.T, recorder *httptest.ResponseRecorder, v interface{}) {
+	if err := json.Unmarshal(recorder.Body.Bytes(), v); err != nil {
+		t.Errorf("Could not unmarshal JSON response: %s", err)
 	}
 }

--- a/internal/service/FileCategories.go
+++ b/internal/service/FileCategories.go
@@ -704,17 +704,21 @@ var ExtToMime = map[string]string{
 }
 
 var MimeToCategory = map[string]model.Category{
-	"application/gzip":             model.CategoryArchive,
-	"application/octet-stream":     model.CategoryBinary,
-	"application/pdf":              model.CategoryDocument,
-	"application/x-7z-compressed":  model.CategoryArchive,
-	"application/x-rar-compressed": model.CategoryArchive,
-	"application/x-tar":            model.CategoryArchive,
-	"application/zip":              model.CategoryArchive,
-	"audio":                        model.CategoryAudio,
-	"image":                        model.CategoryImage,
-	"text":                         model.CategoryDocument,
-	"video":                        model.CategoryVideo,
+	"audio": model.CategoryAudio,
+	"image": model.CategoryImage,
+	"text":  model.CategoryDocument,
+	"video": model.CategoryVideo,
+
+	"application/gzip":                                model.CategoryArchive,
+	"application/octet-stream":                        model.CategoryBinary,
+	"application/pdf":                                 model.CategoryDocument,
+	"application/vnd.oasis.opendocument.presentation": model.CategoryDocument,
+	"application/vnd.oasis.opendocument.spreadsheet":  model.CategoryDocument,
+	"application/vnd.oasis.opendocument.text":         model.CategoryDocument,
+	"application/x-7z-compressed":                     model.CategoryArchive,
+	"application/x-rar-compressed":                    model.CategoryArchive,
+	"application/x-tar":                               model.CategoryArchive,
+	"application/zip":                                 model.CategoryArchive,
 }
 
 func GetFileCategory(name string, mimeType string, isDir bool) (model.Category, string) {

--- a/internal/service/FileSystem.go
+++ b/internal/service/FileSystem.go
@@ -67,6 +67,11 @@ func (fs *FileSystem) GetEntriesForLibrary(library model.Library, parentPath str
 
 func (fs *FileSystem) GetEntryMetadata(library model.Library, path string) (FileInfo, error) {
 	path = fs.cleanRelativePath(path)
+	if path == "/" {
+		// We're at the library root, so this is not a valid entry.
+		return FileInfo{}, os.ErrNotExist
+	}
+
 	parentPath := filepath.Dir(path)
 	target := fs.resolve(library, path)
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -46,7 +46,7 @@ export const App: React.FC = () => {
   return (
     <Switch>
       <Route exact path="/" component={HomePage} />
-      <Route exact path="/files/:library/:path*" component={FilesPage} />
+      <Route exact path="/files/:library/:path?" component={FilesPage} />
       <Route exact path="/logout" component={LogoutPage} />
       <Route exact path="/settings" component={SettingsPage} />
       <Route exact path="/settings/:setting" component={SettingsPage} />

--- a/web/src/pages/FilesPage.scss
+++ b/web/src/pages/FilesPage.scss
@@ -55,13 +55,6 @@
       margin-left: 12px;
       padding: 12px;
 
-      .close {
-        display: inline-block;
-        width: 27px;
-        font-size: 22px;
-        text-align: center;
-      }
-
       .preview {
         margin: 12px;
         height: 240px;

--- a/web/src/pages/FilesPage.spec.tsx
+++ b/web/src/pages/FilesPage.spec.tsx
@@ -56,7 +56,7 @@ describe('FilesPage', () => {
   it('shows the files', async () => {
     await render(<FilesPage />, {
       path: '/files/4',
-      route: '/files/:library/:path*',
+      route: '/files/:library/:path?',
       loggedIn: true,
       initialState,
     });
@@ -69,7 +69,7 @@ describe('FilesPage', () => {
   it('shows file details', async () => {
     await render(<FilesPage />, {
       path: '/files/4',
-      route: '/files/:library/:path*',
+      route: '/files/:library/:path?',
       loggedIn: true,
       initialState,
     });
@@ -107,7 +107,7 @@ describe('FilesPage', () => {
 
     const { navigation } = await render(<FilesPage />, {
       path: '/files/4',
-      route: '/files/:library/:path*',
+      route: '/files/:library/:path?',
       loggedIn: true,
       initialState,
     });
@@ -142,7 +142,7 @@ describe('FilesPage', () => {
 
     const { navigation } = await render(<FilesPage />, {
       path: '/files/4/Documents',
-      route: '/files/:library/:path*',
+      route: '/files/:library/:path?',
       loggedIn: true,
       initialState,
     });
@@ -229,7 +229,7 @@ describe('FilesPage', () => {
 
     await render(<FilesPage />, {
       path: '/files/4',
-      route: '/files/:library/:path*',
+      route: '/files/:library/:path?',
       loggedIn: true,
       initialState,
     });
@@ -283,7 +283,7 @@ describe('FilesPage', () => {
 
     await render(<FilesPage />, {
       path: '/files/4',
-      route: '/files/:library/:path*',
+      route: '/files/:library/:path?',
       loggedIn: true,
       initialState,
     });
@@ -342,7 +342,7 @@ describe('FilesPage', () => {
 
     await render(<FilesPage />, {
       path: '/files/4',
-      route: '/files/:library/:path*',
+      route: '/files/:library/:path?',
       loggedIn: true,
       initialState,
     });
@@ -358,7 +358,7 @@ describe('FilesPage', () => {
   it('cancels creating the folder when blurring the input', async () => {
     await render(<FilesPage />, {
       path: '/files/4',
-      route: '/files/:library/:path*',
+      route: '/files/:library/:path?',
       loggedIn: true,
       initialState,
     });
@@ -374,7 +374,7 @@ describe('FilesPage', () => {
   it('cancels creating the folder when pressing escape', async () => {
     await render(<FilesPage />, {
       path: '/files/4',
-      route: '/files/:library/:path*',
+      route: '/files/:library/:path?',
       loggedIn: true,
       initialState,
     });

--- a/web/src/pages/FilesPage.tsx
+++ b/web/src/pages/FilesPage.tsx
@@ -169,7 +169,7 @@ export const FilesPage: React.FC = () => {
                       }
                     }}
                     onClick={() => setSelectedEntry(entry)}
-                    className={classNames(selectedEntry === entry && 'is-selected')}
+                    className={classNames(selectedEntry?.name === entry.name && 'is-selected')}
                   >
                     <td className="icon">
                       <EntryIcon entry={entry} />

--- a/web/src/pages/FilesPage.tsx
+++ b/web/src/pages/FilesPage.tsx
@@ -94,6 +94,7 @@ export const FilesPage: React.FC = () => {
             onClick={() => history.push(`/files/${libraryId}/${encodeURIComponent(currentDir?.parent || '')}`)}
             aria-label="Parent directory"
             icon="level-up-alt"
+            disabled={!currentDir}
           />
           <h1>{library?.name}</h1>
         </div>

--- a/web/src/pages/FilesPage.tsx
+++ b/web/src/pages/FilesPage.tsx
@@ -181,34 +181,48 @@ export const FilesPage: React.FC = () => {
             </div>
           )}
         </Panel>
-        {selectedEntry || currentDir ? (
-          <EntryDetails entry={(selectedEntry || currentDir) as Entry} />
-        ) : (
-          <Panel className="details" />
-        )}
+        <DetailsPanel entry={selectedEntry || currentDir} library={library} />
       </main>
     </Layout>
   );
 };
 
-const EntryDetails: React.FC<{ entry: Entry }> = ({ entry }) => (
-  <Panel className="details">
-    <div className="preview">
-      <EntryIcon entry={entry} />
-    </div>
-    <div className="name">{entry.name}</div>
-    <div className="category">{entry.category}</div>
-    <div className="columns">
-      <div>
-        <span>Modified</span>
-        <span>{humanReadableDateTime(entry.modified)}</span>
-      </div>
-      {entry.category !== 'Folder' && (
-        <div>
-          <span>Size</span>
-          <span>{humanReadableSize(entry.size)}</span>
+const DetailsPanel: React.FC<{ entry?: Entry; library?: Library }> = ({ entry, library }) => {
+  if (entry) {
+    return (
+      <Panel className="details">
+        <div className="preview">
+          <EntryIcon entry={entry} />
         </div>
-      )}
-    </div>
-  </Panel>
-);
+        <div className="name">{entry.name}</div>
+        <div className="category">{entry.category}</div>
+        <div className="columns">
+          <div>
+            <span>Modified</span>
+            <span>{humanReadableDateTime(entry.modified)}</span>
+          </div>
+          {entry.category !== 'Folder' && (
+            <div>
+              <span>Size</span>
+              <span>{humanReadableSize(entry.size)}</span>
+            </div>
+          )}
+        </div>
+      </Panel>
+    );
+  }
+
+  if (library) {
+    return (
+      <Panel className="details">
+        <div className="preview">
+          <Icon icon="folder" />
+        </div>
+        <div className="name">{library.name}</div>
+        <div className="category">Library: {library.type}</div>
+      </Panel>
+    );
+  }
+
+  return <Panel className="details" />;
+};

--- a/web/src/pages/FilesPage.tsx
+++ b/web/src/pages/FilesPage.tsx
@@ -21,11 +21,25 @@ export const FilesPage: React.FC = () => {
   const libraries = useService(LibrariesService);
   const { library, path } = useParams<{ library: string; path?: string }>();
   const history = useHistory();
+
+  // Current directory info and details.
   const [entries, setEntries] = useState<Entry[]>();
   const [selectedEntry, setSelectedEntry] = useState<Entry>();
+  // TODO: Maybe allow this to be undefined?
+  const [currentDir, setCurrentDir] = useState<Entry>({
+    category: 'Folder',
+    name: '',
+    size: 0,
+    parent: '',
+    modified: new Date().toISOString(),
+  });
+
+  // Current library info.
   const [libraryName, setLibraryName] = useState<string>();
   const { selectors } = useService(librariesStore);
   const librariesList = useAppSelector(selectors.libraries);
+
+  // File and folder operations.
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [newFolderName, setNewFolderName] = useState<string>();
 
@@ -173,7 +187,7 @@ export const FilesPage: React.FC = () => {
             </div>
           )}
         </Panel>
-        {selectedEntry && <EntryDetails entry={selectedEntry} onClose={() => setSelectedEntry(undefined)} />}
+        <EntryDetails entry={selectedEntry || currentDir} />
       </main>
     </Layout>
   );
@@ -181,12 +195,10 @@ export const FilesPage: React.FC = () => {
 
 interface EntryDetailsProps {
   entry: Entry;
-  onClose: () => void;
 }
 
-const EntryDetails: React.FC<EntryDetailsProps> = ({ entry, onClose }) => (
+const EntryDetails: React.FC<EntryDetailsProps> = ({ entry }) => (
   <Panel className="details">
-    <IconButton aria-label="Close details" onClick={onClose} icon="times" />
     <div className="preview">
       <EntryIcon entry={entry} />
     </div>

--- a/web/src/pages/FilesPage.tsx
+++ b/web/src/pages/FilesPage.tsx
@@ -38,9 +38,15 @@ export const FilesPage: React.FC = () => {
   const [newFolderName, setNewFolderName] = useState<string>();
 
   const refresh = useCallback(() => {
+    // If the path is falsy or '/' we're at the library root, so no need for an extra call.
+    const pathIsRoot = !path || path === '/';
+    if (pathIsRoot) {
+      setCurrentDir(undefined);
+    }
+
     return Promise.all([
       libraries.getEntries(libraryId, path).then(sortEntries).then(setEntries),
-      libraries.getEntry(libraryId, path).then(setCurrentDir),
+      pathIsRoot ? undefined : libraries.getEntry(libraryId, path).then(setCurrentDir),
     ]);
   }, [libraries, libraryId, path]);
 

--- a/web/src/services/LibrariesService.ts
+++ b/web/src/services/LibrariesService.ts
@@ -92,6 +92,10 @@ export class LibrariesService {
     return this.api.jsonGet(`/libraries/${libraryId}/entries`, { parent });
   }
 
+  public async getEntry(libraryId: number | string, path: string): Promise<Entry | undefined> {
+    return (await this.api.jsonGet<Entry[]>(`/libraries/${libraryId}/entries`, { path }))[0];
+  }
+
   public uploadFile(libraryId: number | string, parent: string, file: File): Promise<Entry> {
     return this.api.formPost(`/libraries/${libraryId}/entries`, {
       parent,

--- a/web/src/utils/path.spec.ts
+++ b/web/src/utils/path.spec.ts
@@ -1,4 +1,4 @@
-import { parentPath, resolvePath } from './path';
+import { resolvePath } from './path';
 
 describe('resolvePath', () => {
   it.each`
@@ -10,19 +10,5 @@ describe('resolvePath', () => {
     ${'no/leading'}       | ${'slash'}     | ${'/no/leading/slash'}
   `('resolves the path', ({ parent, name, result }) => {
     expect(resolvePath(parent, name)).toBe(result);
-  });
-});
-
-describe('parentPath', () => {
-  it.each`
-    path                    | parent
-    ${''}                   | ${''}
-    ${undefined}            | ${''}
-    ${'/'}                  | ${''}
-    ${'/home/me/Downloads'} | ${'/home/me'}
-    ${'no-slash'}           | ${''}
-    ${'no/leading/slash'}   | ${'/no/leading'}
-  `('returns the parent path', ({ path, parent }) => {
-    expect(parentPath(path)).toBe(parent);
   });
 });

--- a/web/src/utils/path.ts
+++ b/web/src/utils/path.ts
@@ -1,3 +1,4 @@
+// TODO: We shouldn't need this function.
 export function resolvePath(parent: string, name: string): string {
   let result = parent;
   if (!result.endsWith('/')) {
@@ -7,16 +8,4 @@ export function resolvePath(parent: string, name: string): string {
     result = `/${result}`;
   }
   return `${result}${name}`;
-}
-
-export function parentPath(path?: string): string {
-  if (!path || path === '/') {
-    return '';
-  }
-
-  let result = path;
-  if (!result.startsWith('/')) {
-    result = `/${result}`;
-  }
-  return result.substring(0, result.lastIndexOf('/'));
 }

--- a/web/src/utils/path.ts
+++ b/web/src/utils/path.ts
@@ -1,4 +1,3 @@
-// TODO: We shouldn't need this function.
 export function resolvePath(parent: string, name: string): string {
   let result = parent;
   if (!result.endsWith('/')) {


### PR DESCRIPTION
Closes #47 
Closes #52 

This PR also changes all "entries" API calls to require a `path` query parameter, instead of encoding it in the URL path. I did add some tests, except for the create call (since that's a bit more work with multipart requests, and I didn't want to scope creep _too_ much). In an attempt to reduce the amount of test code slightly, I also added some assertion helpers in `assert_test.go` for stuff we use in (almost) every test.